### PR TITLE
Fix typo in GM description in vm-history.md

### DIFF
--- a/docs/ch1/sec1/vm-history.md
+++ b/docs/ch1/sec1/vm-history.md
@@ -78,7 +78,7 @@ Simics 后期加入了时序建模能力（timing models），但其默认模式
 
 让我们把视角再次转回到开源世界：
 
-GM（General Execution-driven Multiprocessor Simulator）和 GEMS（General Execution-driven Multiprocessor Simulator）是由威斯康星大学麦迪逊分校开发的一系列高性能多处理器模拟器。它们专注于模拟大规模并行系统的内存子系统和缓存层次结构。
+GM（General Multiprocessor simulator）和 GEMS（General Execution-driven Multiprocessor Simulator）是由威斯康星大学麦迪逊分校开发的一系列高性能多处理器模拟器。它们专注于模拟大规模并行系统的内存子系统和缓存层次结构。
 
 GEMS 的核心贡献之一就是构建了一个高度可配置、支持细粒度建模的多处理器内存系统仿真框架。而 GM 主要是处理器方面。
 


### PR DESCRIPTION
## 关联章节/文件

- 文档路径：`docs/ch1/sec1/vm-history.md`

## 修改类型

- [ ] 内容补充
- [x] 错别字/语句修正
- [ ] 格式调整
- [ ] 图片/附件更新
- [ ] 代码示例修改
- [ ] 其他 (请说明):

## 修改描述

- `GEMS` 是 *General Execution-driven Multiprocessor Simulator* 的简称很合理，所以 `GM` 的简称不会也是这个。查了一下应该是 *General Multiprocessor simulator*;

## 本地验证

- [ ] 已通过 `autocorrect .` (或 `autocorrect --lint .` 检查并通过)
- [ ] 已执行 `mkdocs serve` 并在本地预览，确认页面渲染正常、链接有效、排版美观